### PR TITLE
NUM-2038 | Fix test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ commands:
             - run:
                 name: CLONE EHRBASE REPO
                 command: |
-                    git clone git@github.com:ehrbase/ehrbase.git
+                    git clone --depth 1 --branch v0.19.0 git@github.com:ehrbase/ehrbase.git
                     ls -la
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ commands:
             - run:
                 name: CLONE EHRBASE REPO
                 command: |
-                    git clone --depth 1 --branch v0.19.0 git@github.com:ehrbase/ehrbase.git
+                    git clone --depth 1 --branch v0.17.2 git@github.com:ehrbase/ehrbase.git
                     ls -la
 
 


### PR DESCRIPTION
These changes fix the pipeline by pinning the EHRbase version used to the latest compatible (`0.17.2`).