### PR TITLE
Use EHRbase containers for tests and pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,17 +80,12 @@ jobs:
         description: |
             Build and test FHIR-bridge, analyze code, collect code coverage metrics,
             upload results to sonarcloud.io
-        executor: docker-py3-java11-postgres
+        executor: docker-py3-java11-dependencies
         steps:
             - checkout
             - install-maven
-            - git-clone-ehrbase-repo
             - cache-out-fhirbridge-m2-dependencies
-            - cache-out-ehrbase-m2-dependencies
-            - build-ehrbase
-            - start-ehrbase-server
             - build-and-test-fhirbridge
-            - cache-in-ehrbase-m2-dependencies
             - cache-in-fhirbridge-m2-dependencies
             - start-fhirbridge-application
             - run-robot-integration-tests
@@ -167,41 +162,6 @@ commands:
     #   Y8,           Y8,        ,8P  88   `8b d8'   88  88   `8b d8'   88    d8""""""""8b    88    `8b 88  88         8P          `8b
     #    Y8a.    .a8P  Y8a.    .a8P   88    `888'    88  88    `888'    88   d8'        `8b   88     `8888  88      .a8P   Y8a     a8P
     #     `"Y8888Y"'    `"Y8888Y"'    88     `8'     88  88     `8'     88  d8'          `8b  88      `888  88888888Y"'     "Y88888P"
-
-
-    git-clone-ehrbase-repo:
-        steps:
-            - run:
-                name: CLONE EHRBASE REPO
-                command: |
-                    git clone --depth 1 --branch v0.17.2 git@github.com:ehrbase/ehrbase.git
-                    ls -la
-
-
-    build-ehrbase:
-        steps:
-            - run:
-                name: BUILD EHRBASE SERVER
-                command: |
-                    ls -la
-                    cd ehrbase
-                    mvn package -Dmaven.javadoc.skip=true -Dmaven.test.skip
-
-
-    start-ehrbase-server:
-        steps:
-            - run:
-                name: START EHRBASE SERVER
-                background: true
-                command: |
-                    ls -la
-                    cd ehrbase
-                    EHRbase_VERSION=$(mvn -q -Dexec.executable="echo" \
-                                             -Dexec.args='${project.version}' \
-                                             --non-recursive exec:exec)
-                    echo ${EHRbase_VERSION}
-                    java -jar "application/target/application-${EHRbase_VERSION}.jar" > log
-
 
     build-and-test-fhirbridge:
         description: | 
@@ -324,22 +284,6 @@ commands:
                 key: fhirbridge-{{ checksum "/tmp/fhirbridge_maven_cache_seed" }}
                 paths:
                 - ~/.m2
-
-    cache-out-ehrbase-m2-dependencies:
-        steps:
-            - run:
-                name: Generate Cache Checksum for EHRbase Dependencies
-                command: find ~/projects/ehrbase -name 'pom.xml' | sort | xargs cat > /tmp/ehrbase_maven_cache_seed
-            - restore_cache:
-                key: EHRbase-v1-
-
-    cache-in-ehrbase-m2-dependencies:
-        steps:
-            - save_cache:
-                key: EHRbase-v1-{{ checksum "/tmp/ehrbase_maven_cache_seed" }}
-                paths:
-                    - ~/.m2
-
 
     configure-git-for-ci-bot:
         steps:
@@ -467,20 +411,30 @@ executors:
         docker:
             - image: cimg/python:3.8.5-node
 
-    docker-py3-java11-postgres:
+    docker-py3-java11-dependencies:
         description: |
-            This executor consists of 3 (THREE) docker images. The first one - the base image -
-            is where all commands are executed. The other two imags are service containers w/
-            PostgreSQL DBs, one for EHRbase, one for FHIRbridge.
-            - EHRbase DB is accessible via localhost:5432
-            - FHRIbridge DB is accessible via fhirdb:5432
+            This executor consists of 4 (FOUR) docker images. The first one - the base image -
+            is where all commands are executed. Then following two images are to run EHRbase,
+            namely a PostgreSQL DB used by EHRbase, and EHRbase itself. The latter image is a
+            PostgreSQL DB used by FHIR Bridge itself
         working_directory: ~/projects
         docker:
             - image: cimg/python:3.8.5-node
             - image: ehrbase/ehrbase-postgres:13.4
+              name: ehrbase-database
               environment:
                 POSTGRES_USER: postgres
                 POSTGRES_PASSWORD: postgres
+            - image: ehrbase/ehrbase:0.17.2
+              name: ehrbase
+              environment:
+                  DB_URL: jdbc:postgresql://ehrbase-database:5432/ehrbase
+                  DB_USER: ehrbase
+                  DB_PASS: ehrbase
+                  AUTH_TYPE: BASIC
+                  AUTH_USER: ehrbase-user
+                  AUTH_PASSWORD: SuperSecretPassword
+                  SYSTEM_NAME: local.ehrbase.org
             - image: postgres:13.4
               name: fhirdb
               environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ orbs:
 
 
 executors:
-    docker-python3-java11:
+    docker-py3-java11:
         working_directory: ~/projects
         docker:
             - image: cimg/python:3.8.5-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
 
     build-and-quicktest-fhirbridge:
         description: Build and test FHIR-bridge
-        executor: docker-py3-java11
+        executor: docker-py3-java11-dependencies
         steps:
             - checkout
             - install-maven
@@ -173,7 +173,7 @@ commands:
                 name: BUILD FHIR-BRIDGE
                 command: |
                     ls -la
-                    mvn clean verify -Dmaven.javadoc.skip=true
+                    USETESTCONTAINERS=false mvn clean verify -Dmaven.javadoc.skip=true -Dspring.profiles.active=ci
 
 
     start-fhirbridge-application:
@@ -426,7 +426,6 @@ executors:
                 POSTGRES_USER: postgres
                 POSTGRES_PASSWORD: postgres
             - image: ehrbase/ehrbase:0.17.2
-              name: ehrbase
               environment:
                   DB_URL: jdbc:postgresql://ehrbase-database:5432/ehrbase
                   DB_USER: ehrbase

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,17 +64,12 @@ jobs:
 
     build-and-quicktest-fhirbridge:
         description: Build and test FHIR-bridge
-        executor: docker-py3-java11-postgres
+        executor: docker-py3-java11
         steps:
             - checkout
             - install-maven
-            - git-clone-ehrbase-repo
             - cache-out-fhirbridge-m2-dependencies
-            - cache-out-ehrbase-m2-dependencies
-            - build-ehrbase
-            - start-ehrbase-server
             - build-and-test-fhirbridge
-            - cache-in-ehrbase-m2-dependencies
             - cache-in-fhirbridge-m2-dependencies
             # - collect-fhirbridge-unittest-results
             - collect-fhirbridge-integrationtest-results
@@ -212,37 +207,13 @@ commands:
         description: | 
             Executes `mvn clean verify`
         steps:
-            - run:
-                name: WAIT FOR EHRBASE SERVER TO BE READY
-                command: |
-                    ls -la
-                    timeout=30
-                    while [ ! -f ehrbase/log ];
-                        do
-                            echo "Waiting for file ehrbase/log ..."
-                            if [ "$timeout" == 0 ]; then
-                                echo "ERROR: timed out while waiting for file ehrbase/log"
-                                exit 1
-                            fi
-                            sleep 1
-                        ((timeout--))
-                    done
-                    while ! (cat ehrbase/log | grep -m 1 "Started EhrBase in");
-                        do
-                            echo "waiting for EHRbase to be ready ...";
-                            if [ "$timeout" == 0 ]; then
-                                echo "WARNING: Did not see a startup message even after waiting 30s"
-                                exit 1
-                            fi
-                            sleep 1;
-                        ((timeout--))
-                    done
-                    echo "REMAINING TIMEOUT: $timeout"
+            - setup_remote_docker:
+                  version: 19.03.13
             - run:
                 name: BUILD FHIR-BRIDGE
                 command: |
                     ls -la
-                    mvn clean verify -Dmaven.javadoc.skip=true -Dspring.profiles.active=ci
+                    mvn clean verify -Dmaven.javadoc.skip=true
 
 
     start-fhirbridge-application:

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
         <woodstox.version>6.1.1</woodstox.version>
         <ehrbase-sdk.version>v0.3.7</ehrbase-sdk.version>
+        <testcontainers.version>1.17.5</testcontainers.version>
     </properties>
 
     <build>
@@ -223,6 +224,16 @@
             <version>1.4.200</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -316,6 +327,13 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,12 @@
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>client</artifactId>
             <version>${ehrbase-sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Test Dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,8 @@
-ehrbase:
-  address: localhost
-  port: 8080
-  path: /ehrbase/rest/openehr/v1/
+server:
+  servlet:
+    context-path: /fhir-bridge
+  port: 8888
+
 fhir-bridge:
   fhir:
     narrative-generation: false
@@ -11,6 +12,12 @@ fhir-bridge:
         mode: off
         #remote:
         #server-url: https://r4.ontoserver.csiro.au/fhir/
+
+ehrbase:
+  address: localhost
+  port: 8080
+  path: /ehrbase/rest/openehr/v1/
+
 logging:
   level:
     ca.uhn.fhir: warn
@@ -19,10 +26,7 @@ logging:
     org.hl7.fhir: warn
     org.quartz: warn
     org.springframework: warn
-server:
-  servlet:
-    context-path: /fhir-bridge
-  port: 8888
+
 spring:
   batch:
     job:
@@ -33,5 +37,5 @@ spring:
     open-in-view: false
     properties:
       hibernate.search.lucene_version: LUCENE_CURRENT
-      hibernate.search.default.indexBase: ./lucene
+      hibernate.search.default.indexBase: target/lucene
       hibernate.search.model_mapping: ca.uhn.fhir.jpa.search.LuceneSearchMappingFactory

--- a/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
+++ b/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.ehrbase.fhirbridge;
 
 import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
@@ -9,6 +10,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class AbstractIntegrationTest {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractIntegrationTest.class);
@@ -47,9 +49,9 @@ public class AbstractIntegrationTest {
                 .withExposedPorts(EHRBASE_SERVICE_PORT)
                 .waitingFor(Wait.forLogMessage(".*Started EhrBase in.*", 1));
 
-        log.info("Starting EHRbase database...");
+        log.info("Starting EHRbase...");
         ehrbaseContainer.start();
-        log.info("EHRbase database started.");
+        log.info("EHRbase started.");
     }
 
     @DynamicPropertySource

--- a/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
+++ b/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
@@ -15,50 +15,59 @@ public class AbstractIntegrationTest {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractIntegrationTest.class);
 
-    private static final int EHRBASE_SERVICE_PORT = 8080;
+    private static GenericContainer<?> ehrbaseContainer;
 
-    private static final GenericContainer<?> ehrbaseContainer;
+    private static boolean useTestContainers = true;
 
     static {
-        Network ehrbaseNetwork = Network.newNetwork();
+        String useTestContainersEnv = System.getenv("USETESTCONTAINERS");
+        if (useTestContainersEnv != null) {
+            useTestContainers = Boolean.parseBoolean(useTestContainersEnv);
+        }
 
-        GenericContainer<?> ehrbaseDatabaseContainer =
-                new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase-postgres:13.4"))
-                        .withNetwork(ehrbaseNetwork)
-                        .withNetworkAliases("ehrbase-database")
-                        .withEnv("POSTGRES_USER", "postgres")
-                        .withEnv("POSTGRES_PASSWORD", "postgres")
-                        .withEnv("EHRBASE_USER", "ehrbase")
-                        .withEnv("EHRBASE_PASSWORD", "ehrbase")
-                        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2));
+        if (useTestContainers) {
+            Network ehrbaseNetwork = Network.newNetwork();
 
-        log.info("Starting EHRbase database...");
-        ehrbaseDatabaseContainer.start();
-        log.info("EHRbase database started.");
+            GenericContainer<?> ehrbaseDatabaseContainer =
+                    new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase-postgres:13.4"))
+                            .withNetwork(ehrbaseNetwork)
+                            .withNetworkAliases("ehrbase-database")
+                            .withEnv("POSTGRES_USER", "postgres")
+                            .withEnv("POSTGRES_PASSWORD", "postgres")
+                            .withEnv("EHRBASE_USER", "ehrbase")
+                            .withEnv("EHRBASE_PASSWORD", "ehrbase")
+                            .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2));
 
-        ehrbaseContainer = new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase:0.17.2"))
-                .dependsOn(ehrbaseDatabaseContainer)
-                .withNetwork(ehrbaseNetwork)
-                .withEnv("DB_URL", "jdbc:postgresql://ehrbase-database:5432/ehrbase")
-                .withEnv("DB_USER", "ehrbase")
-                .withEnv("DB_PASS", "ehrbase")
-                .withEnv("AUTH_TYPE", "BASIC")
-                .withEnv("AUTH_USER", "ehrbase-user")
-                .withEnv("AUTH_PASSWORD", "SuperSecretPassword")
-                .withEnv("SYSTEM_NAME", "local.ehrbase.org")
-                .withExposedPorts(EHRBASE_SERVICE_PORT)
-                .waitingFor(Wait.forLogMessage(".*Started EhrBase in.*", 1));
+            log.info("Starting EHRbase database...");
+            ehrbaseDatabaseContainer.start();
+            log.info("EHRbase database started.");
 
-        log.info("Starting EHRbase...");
-        ehrbaseContainer.start();
-        log.info("EHRbase started.");
+            ehrbaseContainer = new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase:0.17.2"))
+                    .dependsOn(ehrbaseDatabaseContainer)
+                    .withNetwork(ehrbaseNetwork)
+                    .withEnv("DB_URL", "jdbc:postgresql://ehrbase-database:5432/ehrbase")
+                    .withEnv("DB_USER", "ehrbase")
+                    .withEnv("DB_PASS", "ehrbase")
+                    .withEnv("AUTH_TYPE", "BASIC")
+                    .withEnv("AUTH_USER", "ehrbase-user")
+                    .withEnv("AUTH_PASSWORD", "SuperSecretPassword")
+                    .withEnv("SYSTEM_NAME", "local.ehrbase.org")
+                    .withExposedPorts(8080)
+                    .waitingFor(Wait.forLogMessage(".*Started EhrBase in.*", 1));
+
+            log.info("Starting EHRbase...");
+            ehrbaseContainer.start();
+            log.info("EHRbase started.");
+        }
     }
 
     @DynamicPropertySource
     private static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("ehrbase.address", ehrbaseContainer::getHost);
-        registry.add("ehrbase.port", () -> ehrbaseContainer.getMappedPort(EHRBASE_SERVICE_PORT));
-        registry.add("ehrbase.path", () -> "/ehrbase/rest/openehr/v1/");
+        if (useTestContainers) {
+            registry.add("ehrbase.address", ehrbaseContainer::getHost);
+            registry.add("ehrbase.port", () -> ehrbaseContainer.getMappedPort(8080));
+            registry.add("ehrbase.path", () -> "/ehrbase/rest/openehr/v1/");
+        }
     }
 
 }

--- a/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
+++ b/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
@@ -64,6 +64,12 @@ public class AbstractIntegrationTest {
     @DynamicPropertySource
     private static void setProperties(DynamicPropertyRegistry registry) {
         if (useTestContainers) {
+            registry.add("spring.datasource.url", () -> "jdbc:h2:mem:test_mem");
+            registry.add("spring.datasource.username", () -> "sa");
+            registry.add("spring.datasource.password", () -> "null");
+            registry.add("spring.datasource.driverClassName", () -> "org.h2.Driver");
+            registry.add("spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.H2Dialect");
+
             registry.add("ehrbase.address", ehrbaseContainer::getHost);
             registry.add("ehrbase.port", () -> ehrbaseContainer.getMappedPort(8080));
             registry.add("ehrbase.path", () -> "/ehrbase/rest/openehr/v1/");

--- a/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
+++ b/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
@@ -1,0 +1,52 @@
+package org.ehrbase.fhirbridge;
+
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AbstractIntegrationTest {
+
+    private static final int EHRBASE_SERVICE_PORT = 8080;
+
+    private static final GenericContainer<?> ehrbaseContainer;
+
+    static {
+        Network ehrbaseNetwork = Network.newNetwork();
+        GenericContainer<?> ehrbaseDatabaseContainer =
+                new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase-postgres:13.4"))
+                        .withNetwork(ehrbaseNetwork)
+                        .withNetworkAliases("ehrbase-database")
+                        .withEnv("POSTGRES_USER", "postgres")
+                        .withEnv("POSTGRES_PASSWORD", "postgres")
+                        .withEnv("EHRBASE_USER", "ehrbase")
+                        .withEnv("EHRBASE_PASSWORD", "ehrbase")
+                        .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2));
+        ehrbaseDatabaseContainer.start();
+        ehrbaseContainer = new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase:0.19.0"))
+                .dependsOn(ehrbaseDatabaseContainer)
+                .withNetwork(ehrbaseNetwork)
+                .withEnv("DB_URL", "jdbc:postgresql://ehrbase-database:5432/ehrbase")
+                .withEnv("DB_USER", "ehrbase")
+                .withEnv("DB_PASS", "ehrbase")
+                .withEnv("AUTH_TYPE", "BASIC")
+                .withEnv("AUTH_USER", "ehrbase-user")
+                .withEnv("AUTH_PASSWORD", "SuperSecretPassword")
+                .withEnv("SYSTEM_NAME", "local.ehrbase.org")
+                .withExposedPorts(EHRBASE_SERVICE_PORT)
+                .waitingFor(Wait.forLogMessage(".*Started EhrBase in.*", 1));
+        ehrbaseContainer.start();
+    }
+
+    @DynamicPropertySource
+    private static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("ehrbase.address", ehrbaseContainer::getHost);
+        registry.add("ehrbase.port", () -> ehrbaseContainer.getMappedPort(EHRBASE_SERVICE_PORT));
+        registry.add("ehrbase.path", () -> "/ehrbase/rest/openehr/v1/");
+    }
+
+}

--- a/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
+++ b/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
@@ -11,12 +11,15 @@ import org.testcontainers.utility.DockerImageName;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AbstractIntegrationTest {
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractIntegrationTest.class);
+
     private static final int EHRBASE_SERVICE_PORT = 8080;
 
     private static final GenericContainer<?> ehrbaseContainer;
 
     static {
         Network ehrbaseNetwork = Network.newNetwork();
+
         GenericContainer<?> ehrbaseDatabaseContainer =
                 new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase-postgres:13.4"))
                         .withNetwork(ehrbaseNetwork)
@@ -26,7 +29,11 @@ public class AbstractIntegrationTest {
                         .withEnv("EHRBASE_USER", "ehrbase")
                         .withEnv("EHRBASE_PASSWORD", "ehrbase")
                         .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2));
+
+        log.info("Starting EHRbase database...");
         ehrbaseDatabaseContainer.start();
+        log.info("EHRbase database started.");
+
         ehrbaseContainer = new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase:0.17.2"))
                 .dependsOn(ehrbaseDatabaseContainer)
                 .withNetwork(ehrbaseNetwork)
@@ -39,7 +46,10 @@ public class AbstractIntegrationTest {
                 .withEnv("SYSTEM_NAME", "local.ehrbase.org")
                 .withExposedPorts(EHRBASE_SERVICE_PORT)
                 .waitingFor(Wait.forLogMessage(".*Started EhrBase in.*", 1));
+
+        log.info("Starting EHRbase database...");
         ehrbaseContainer.start();
+        log.info("EHRbase database started.");
     }
 
     @DynamicPropertySource

--- a/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
+++ b/src/test/java/org/ehrbase/fhirbridge/AbstractIntegrationTest.java
@@ -27,7 +27,7 @@ public class AbstractIntegrationTest {
                         .withEnv("EHRBASE_PASSWORD", "ehrbase")
                         .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2));
         ehrbaseDatabaseContainer.start();
-        ehrbaseContainer = new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase:0.19.0"))
+        ehrbaseContainer = new GenericContainer<>(DockerImageName.parse("ehrbase/ehrbase:0.17.2"))
                 .dependsOn(ehrbaseDatabaseContainer)
                 .withNetwork(ehrbaseNetwork)
                 .withEnv("DB_URL", "jdbc:postgresql://ehrbase-database:5432/ehrbase")

--- a/src/test/java/org/ehrbase/fhirbridge/FhirBridgeApplicationIT.java
+++ b/src/test/java/org/ehrbase/fhirbridge/FhirBridgeApplicationIT.java
@@ -38,8 +38,6 @@ import java.util.UUID;
 /**
  * Integration Tests
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class FhirBridgeApplicationIT extends AbstractIntegrationTest {
 
     private final Logger logger = LoggerFactory.getLogger(FhirBridgeApplicationIT.class);

--- a/src/test/java/org/ehrbase/fhirbridge/FhirBridgeApplicationIT.java
+++ b/src/test/java/org/ehrbase/fhirbridge/FhirBridgeApplicationIT.java
@@ -40,7 +40,7 @@ import java.util.UUID;
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class FhirBridgeApplicationIT {
+public class FhirBridgeApplicationIT extends AbstractIntegrationTest {
 
     private final Logger logger = LoggerFactory.getLogger(FhirBridgeApplicationIT.class);
 
@@ -82,6 +82,7 @@ public class FhirBridgeApplicationIT {
 
         ehrStatus.setArchetypeNodeId("openEHR-EHR-EHR_STATUS.generic.v1");
         ehrStatus.setName(new DvText("test status"));
+        ehrStatus.setModifiable(true);
 
         UUID ehrId = service.createEhr(ehrStatus);
 
@@ -455,7 +456,7 @@ public class FhirBridgeApplicationIT {
         Assertions.assertNotNull(outcome.getResource());
         Assertions.assertEquals("1", outcome.getResource().getMeta().getVersionId());
     }
-    
+
     @Test
     public void createRespRate() throws IOException {
         String resource = getContent("classpath:/Observation/observation-example-respiratory-rate.json");
@@ -498,7 +499,7 @@ public class FhirBridgeApplicationIT {
         Assertions.assertNotNull(outcome.getResource());
         Assertions.assertEquals("1", outcome.getResource().getMeta().getVersionId());
     }
-  
+
     @Test
     public void createBodyWeight() throws IOException {
         String resource = getContent("classpath:/Observation/observation-example-body-weight.json");
@@ -511,7 +512,7 @@ public class FhirBridgeApplicationIT {
         Assertions.assertNotNull(outcome.getResource());
         Assertions.assertEquals("1", outcome.getResource().getMeta().getVersionId());
     }
-    
+
     @Test
     public void createSofaScore() throws IOException {
         String resource = getContent("classpath:/Observation/observation-sofa-score-example.json");

--- a/src/test/java/org/ehrbase/fhirbridge/FhirBridgeApplicationIT.java
+++ b/src/test/java/org/ehrbase/fhirbridge/FhirBridgeApplicationIT.java
@@ -82,7 +82,6 @@ public class FhirBridgeApplicationIT extends AbstractIntegrationTest {
 
         ehrStatus.setArchetypeNodeId("openEHR-EHR-EHR_STATUS.generic.v1");
         ehrStatus.setName(new DvText("test status"));
-        ehrStatus.setModifiable(true);
 
         UUID ehrId = service.createEhr(ehrStatus);
 

--- a/src/test/resources/application-ci.yml
+++ b/src/test/resources/application-ci.yml
@@ -1,16 +1,3 @@
-server:
-  servlet:
-    context-path: /fhir-bridge
-  port: 8888
-
-fhir-bridge:
-  fhir:
-    narrative-generation: false
-    url-mapping: /fhir/*
-    validation:
-      terminology:
-        mode: off
-
 ehrbase:
   address: localhost
   port: 8080
@@ -21,8 +8,3 @@ spring:
     url: jdbc:postgresql://fhirdb:5432/fhir_bridge
     username: fhir_bridge
     password: fhir_bridge
-    driver-class-name: org.postgresql.Driver
-  jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQL94Dialect

--- a/src/test/resources/application-ci.yml
+++ b/src/test/resources/application-ci.yml
@@ -1,7 +1,8 @@
-ehrbase:
-  address: localhost
-  port: 8080
-  path: /ehrbase/rest/openehr/v1/
+server:
+  servlet:
+    context-path: /fhir-bridge
+  port: 8888
+
 fhir-bridge:
   fhir:
     narrative-generation: false
@@ -9,31 +10,14 @@ fhir-bridge:
     validation:
       terminology:
         mode: off
-logging:
-  level:
-    ca.uhn.fhir: warn
-    org.ehrbase.fhirbridge: info
-    org.hibernate: warn
-    org.hl7.fhir: warn
-    org.quartz: warn
-    org.springframework: warn
-server:
-  servlet:
-    context-path: /fhir-bridge
-  port: 8888
+
+ehrbase:
+  address: ehrbase
+  port: 8080
+  path: /ehrbase/rest/openehr/v1/
+
 spring:
-  batch:
-    job:
-      enabled: false
   datasource:
     url: jdbc:postgresql://fhirdb:5432/fhir_bridge
     username: fhir_bridge
     password: fhir_bridge
-  jpa:
-    hibernate:
-      ddl-auto: update
-    open-in-view: false
-    properties:
-      hibernate.search.lucene_version: LUCENE_CURRENT
-      hibernate.search.default.indexBase: ./lucene
-      hibernate.search.model_mapping: ca.uhn.fhir.jpa.search.LuceneSearchMappingFactory

--- a/src/test/resources/application-ci.yml
+++ b/src/test/resources/application-ci.yml
@@ -12,7 +12,7 @@ fhir-bridge:
         mode: off
 
 ehrbase:
-  address: ehrbase
+  address: localhost
   port: 8080
   path: /ehrbase/rest/openehr/v1/
 
@@ -21,3 +21,8 @@ spring:
     url: jdbc:postgresql://fhirdb:5432/fhir_bridge
     username: fhir_bridge
     password: fhir_bridge
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQL94Dialect

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,8 @@
-ehrbase:
-  address: localhost
-  port: 8080
-  path: /ehrbase/rest/openehr/v1/
+server:
+  servlet:
+    context-path: /fhir-bridge
+  port: 8888
+
 fhir-bridge:
   fhir:
     narrative-generation: false
@@ -9,18 +10,12 @@ fhir-bridge:
     validation:
       terminology:
         mode: off
-logging:
-  level:
-    ca.uhn.fhir: warn
-    org.ehrbase.fhirbridge: info
-    org.hibernate: warn
-    org.hl7.fhir: warn
-    org.quartz: warn
-    org.springframework: warn
-server:
-  servlet:
-    context-path: /fhir-bridge
-  port: 8888
+
+ehrbase:
+  address: localhost
+  port: 8080
+  path: /ehrbase/rest/openehr/v1/
+
 spring:
   batch:
     job:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -25,11 +25,11 @@ spring:
   batch:
     job:
       enabled: false
+  datasource:
+    url: jdbc:h2:mem:test_mem
+    username: sa
+    password: null
+    driverClassName: org.h2.Driver
   jpa:
-    hibernate:
-      ddl-auto: update
-    open-in-view: false
     properties:
-      hibernate.search.lucene_version: LUCENE_CURRENT
-      hibernate.search.default.indexBase: ./lucene
-      hibernate.search.model_mapping: ca.uhn.fhir.jpa.search.LuceneSearchMappingFactory
+      hibernate.dialect: org.hibernate.dialect.H2Dialect

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -33,3 +33,6 @@ spring:
   jpa:
     properties:
       hibernate.dialect: org.hibernate.dialect.H2Dialect
+      hibernate.search.lucene_version: LUCENE_CURRENT
+      hibernate.search.default.indexBase: ./lucene
+      hibernate.search.model_mapping: ca.uhn.fhir.jpa.search.LuceneSearchMappingFactory

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -20,14 +20,11 @@ spring:
   batch:
     job:
       enabled: false
-  datasource:
-    url: jdbc:h2:mem:test_mem
-    username: sa
-    password: null
-    driverClassName: org.h2.Driver
   jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
     properties:
-      hibernate.dialect: org.hibernate.dialect.H2Dialect
       hibernate.search.lucene_version: LUCENE_CURRENT
-      hibernate.search.default.indexBase: ./lucene
+      hibernate.search.default.indexBase: target/lucene
       hibernate.search.model_mapping: ca.uhn.fhir.jpa.search.LuceneSearchMappingFactory

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>


### PR DESCRIPTION
These changes expand the use of containers in two contexts:
1. The integration test suite makes use of [testcontainers](https://www.testcontainers.org/) to start up the external dependencies it needs; this way the suite can be run in a self-contained manner
2. The CircleCI pipeline starts EHRbase as a container, rather than building it from source.

In order to make the integration test suite usable in the pipeline, setting environment variable `USETESTCONTAINERS` to `false` prevents the containers from running and starts the app against the endpoints configured via application properties. For the pipeline, Spring profile `ci` is used.